### PR TITLE
fix version dependancies after xmldom update

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "xmldom": "~0.1.19",
+    "xmldom": "0.1.19",
     "xpath": "0.0.7",
-    "css": "~2.1.0",
-    "svgpath": "~1.0.6"
+    "css": "2.1.0",
+    "svgpath": "1.0.6"
   }
 }


### PR DESCRIPTION
xmldom has been updated to 0.1.20.
The serializeToString call does not work on this version.
To avoid further error on a dependancy update, we use fixed versions for them.
